### PR TITLE
Try 3 times before failing to talk to pkgdb2.

### DIFF
--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import requests
+import requests.exceptions
 
 from dogpile.cache import make_region
 
@@ -24,7 +25,16 @@ def get_packagers_of_package(config, package):
 
     @_cache.cache_on_arguments()
     def _getter(package):
-        return _get_pkgdb2_packagers_for(config, package)
+        """ Cached access to pkgdb2 """
+        def _get(attempt=0):
+            """ Try at most three times before giving up if err """
+            try:
+                return _get_pkgdb2_packagers_for(config, package)
+            except requests.exceptions.ConnectionError:
+                if attempt >= 3:
+                    raise
+                return _get(attempt + 1)
+        return _get()
 
     return _getter(package)
 


### PR DESCRIPTION
This should hopefully cut down on the fedmsg error mails.  Almost all of them 
these days are from the connection to pkgdb2 failing for some reason (once an 
hour-ish?).
