### PR TITLE
Less formal short-descriptions for rules.

### DIFF
--- a/fmn/rules/anitya.py
+++ b/fmn/rules/anitya.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('anitya.distro.add', prefix='org.release-monitoring')])
 def anitya_distro_add(config, message):
-    """ Upstream: a distribution is added
+    """ New distributions added to release-monitoring.org
 
     Adding this rule will trigger notifications when a new distribution is
     **added** to `anitya <release-monitoring.org>`_.
@@ -13,7 +13,7 @@ def anitya_distro_add(config, message):
 
 @hint(topics=[_('anitya.distro.edit', prefix='org.release-monitoring')])
 def anitya_distro_update(config, message):
-    """ Upstream: a distribution has been updated
+    """ Anitya distributions updated
 
     Adding this rule will trigger notifications when a distribution is
     **updated** in `anitya <release-monitoring.org>`_.
@@ -23,7 +23,7 @@ def anitya_distro_update(config, message):
 
 @hint(topics=[_('anitya.project.add', prefix='org.release-monitoring')])
 def anitya_project_add(config, message):
-    """ Upstream: a project is added
+    """ New projects added to release-monitoring.org
 
     Adding this rule will trigger notifications when a project is **added**
     to `anitya <release-monitoring.org>`_.
@@ -33,7 +33,7 @@ def anitya_project_add(config, message):
 
 @hint(topics=[_('anitya.project.add.tried', prefix='org.release-monitoring')])
 def anitya_project_add_tried(config, message):
-    """ Upstream: a project is tried to be added
+    """ Attempts to add new projects to release-monitoring.org
 
     Adding this rule will trigger notifications when a project is tried to
     be **added** to `anitya <release-monitoring.org>`_.
@@ -43,7 +43,7 @@ def anitya_project_add_tried(config, message):
 
 @hint(topics=[_('anitya.project.edit', prefix='org.release-monitoring')])
 def anitya_project_update(config, message):
-    """ Upstream: a project has been updated
+    """ Updates to projects on release-monitoring.org
 
     Adding this rule will trigger notifications when a project is **updated**
     in `anitya <release-monitoring.org>`_.
@@ -53,7 +53,7 @@ def anitya_project_update(config, message):
 
 @hint(topics=[_('anitya.project.map.new', prefix='org.release-monitoring')])
 def anitya_mapping_new(config, message):
-    """ Upstream: a new mapping of a project to a distribution has been added
+    """ When upstream projects are mapped to downstream packages
 
     Adding this rule will trigger notifications when a new mapping of a
     project to a distribution is **added** in `anitya
@@ -64,7 +64,7 @@ def anitya_mapping_new(config, message):
 
 @hint(topics=[_('anitya.project.map.update', prefix='org.release-monitoring')])
 def anitya_mapping_update(config, message):
-    """ Upstream: the mapping of a project to a distribution has been updated
+    """ Updates to anitya's upstream/downstream mappings
 
     Adding this rule will trigger notifications when the mapping of a
     project to a distribution is **updated** in `anitya
@@ -75,7 +75,7 @@ def anitya_mapping_update(config, message):
 
 @hint(topics=[_('anitya.project.map.remove', prefix='org.release-monitoring')])
 def anitya_mapping_deleted(config, message):
-    """ Upstream: a mapping of a project to a distribution has been deleted
+    """ When upstream/downstream mappings are deleted
 
     Adding this rule will trigger notifications when the mapping of a
     project in a distribution is **deleted** in `anitya
@@ -86,7 +86,7 @@ def anitya_mapping_deleted(config, message):
 
 @hint(topics=[_('anitya.project.remove', prefix='org.release-monitoring')])
 def anitya_project_deleted(config, message):
-    """ Upstream: a project is deleted
+    """ When upstream projects are deleted from anitya
 
     Adding this rule will trigger notifications when a project is **deleted**
     to `anitya <release-monitoring.org>`_.
@@ -97,7 +97,7 @@ def anitya_project_deleted(config, message):
 @hint(topics=[_('anitya.project.version.update',
                 prefix='org.release-monitoring')])
 def anitya_new_update(config, message):
-    """ Upstream: a project has an update
+    """ When new upstream releases are detected
 
     Adding this rule will trigger notifications when a project has a
     **new release** according to `anitya <release-monitoring.org>`_.
@@ -107,7 +107,7 @@ def anitya_new_update(config, message):
 
 @hint(topics=[_('anitya.project.update', prefix='org.release-monitoring')])
 def anitya_info_update(config, message):
-    """ Upstream: a project has been updated
+    """ When an upstream project's metadata is updated
 
     Adding this rule will trigger notifications when the information about
     a project are **updated** in `anitya <release-monitoring.org>`_.

--- a/fmn/rules/ansible.py
+++ b/fmn/rules/ansible.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('ansible.playbook.complete')])
 def playbook_complete(config, message):
-    """ Ansible playbook completed
+    """ Fedora-infra playbook runs finishing
 
     The `Fedora Infrastructure team
     <https://fedoraproject.org/wiki/Infrastructure>`_ uses `ansible
@@ -16,7 +16,7 @@ def playbook_complete(config, message):
 
 @hint(topics=[_('ansible.playbook.start')])
 def playbook_started(config, message):
-    """ Ansible playbook started
+    """ Fedora-infra playbook runs starting
 
     The `Fedora Infrastructure team
     <https://fedoraproject.org/wiki/Infrastructure>`_ uses `ansible

--- a/fmn/rules/askbot.py
+++ b/fmn/rules/askbot.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('askbot.post.delete')])
 def askbot_post_deleted(config, message):
-    """ Ask: post deleted
+    """ Deleted Ask Fedora posts
 
     This rule will let through messages that get sent when either
     a question or an answer are **deleted** from the `Ask Fedora
@@ -14,7 +14,7 @@ def askbot_post_deleted(config, message):
 
 @hint(topics=[_('askbot.post.edit')])
 def askbot_post_edited(config, message):
-    """ Ask: post edited
+    """ Updates to Ask Fedora posts
 
     This rule will let through messages that get sent when either
     a question or an answer are **edited** on the `Ask Fedora
@@ -25,7 +25,7 @@ def askbot_post_edited(config, message):
 
 @hint(topics=[_('askbot.post.flag_offensive.add')])
 def askbot_post_flagged_offensive(config, message):
-    """ Ask: post flagged as offensive
+    """ When Ask Fedora posts are flagged as 'offensive'
 
     Sometimes, people are rude.  This rule will let you get notified whenever
     a post is **flagged as offensive** on the `Ask Fedora
@@ -36,7 +36,7 @@ def askbot_post_flagged_offensive(config, message):
 
 @hint(topics=[_('askbot.post.flag_offensive.delete')])
 def askbot_post_unflagged_offensive(config, message):
-    """ Ask: post unflagged as offensive
+    """ When Ask Fedora posts are unflagged as 'offensive'
 
     Sometimes, people are rude.  This rule will let you get notified whenever
     a post is **unflagged as offensive** on the `Ask Fedora
@@ -47,7 +47,7 @@ def askbot_post_unflagged_offensive(config, message):
 
 @hint(topics=[_('askbot.tag.update')])
 def askbot_tag_update(config, message):
-    """ Ask: tag update
+    """ Tags altered on Ask Fedora posts
 
     This rule lets through messages indicating that **tags** on an
     `Ask Fedora <https://ask.fedoraproject.org/questions>`_ post have been

--- a/fmn/rules/bodhi.py
+++ b/fmn/rules/bodhi.py
@@ -1,9 +1,9 @@
 from fmn.lib.hinting import hint, prefixed as _
 
 
-# No hint for critpath -- it is not invertible.
+@hint(categories=['bodhi'], invertible=False)
 def bodhi_critpath(config, message):
-    """ Bodhi: Any critpath update
+    """ Critpath updates (of any kind)
 
     Adding this rule will allow through notifications about **critpath
     updates** from the `Bodhi Updates System
@@ -14,7 +14,7 @@ def bodhi_critpath(config, message):
 
 @hint(topics=[_('bodhi.buildroot_override.tag')])
 def bodhi_buildroot_override_tag(config, message):
-    """ Bodhi: A user requested a buildroot override
+    """ New buildroot overrides
 
     Adding this rule will allow through notifications whenever a user
     **requests a buildroot override** via the `Bodhi Updates System
@@ -25,7 +25,7 @@ def bodhi_buildroot_override_tag(config, message):
 
 @hint(topics=[_('bodhi.buildroot_override.untag')])
 def bodhi_buildroot_override_untag(config, message):
-    """ Bodhi: A user removed a buildroot override
+    """ Buildroot overrides being removed
 
     Adding this rule will allow through notifications whenever a user
     **delets a request for a buildroot override** via the `Bodhi Updates System
@@ -36,7 +36,7 @@ def bodhi_buildroot_override_untag(config, message):
 
 @hint(topics=[_('bodhi.update.comment')])
 def bodhi_update_comment(config, message):
-    """ Bodhi: a user added a comment to a bodhi update
+    """ Bodhi comments
 
     As part of the QA process, users may comment on updates in
     the `Bodhi Updates System <https://admin.fedoraproject.org/updates>`_.
@@ -47,7 +47,7 @@ def bodhi_update_comment(config, message):
 
 @hint(topics=[_('bodhi.update.request.obsolete')])
 def bodhi_update_request_obsolete(config, message):
-    """ Bodhi: a user requested an update be obsoleted
+    """ Bodhi updates being obsoleted
 
     This rule will let through messages from the `Bodhi Updates System
     <https://admin.fedoraproject.org/updates>`_ indicating that a user has
@@ -58,7 +58,7 @@ def bodhi_update_request_obsolete(config, message):
 
 @hint(topics=[_('bodhi.update.request.revoke')])
 def bodhi_update_request_revoke(config, message):
-    """ Bodhi: a user revoked a prior request on an update
+    """ Bodhi having their request revoked
 
     This rule will let through messages from the `Bodhi Updates System
     <https://admin.fedoraproject.org/updates>`_ indicating that a user has
@@ -69,7 +69,7 @@ def bodhi_update_request_revoke(config, message):
 
 @hint(topics=[_('bodhi.update.request.stable')])
 def bodhi_update_request_stable(config, message):
-    """ Bodhi: a user requested an update be marked as stable
+    """ Requests for "stable" status on Bodhi updates
 
     This rule will let through messages from the `Bodhi Updates System
     <https://admin.fedoraproject.org/updates>`_ indicating that a user has
@@ -80,7 +80,7 @@ def bodhi_update_request_stable(config, message):
 
 @hint(topics=[_('bodhi.update.request.testing')])
 def bodhi_update_request_testing(config, message):
-    """ Bodhi: a user requested an update be pushed to testing
+    """ New updates requested for updates-testing
 
     This rule will let through messages from the `Bodhi Updates System
     <https://admin.fedoraproject.org/updates>`_ indicating that a user has
@@ -91,7 +91,7 @@ def bodhi_update_request_testing(config, message):
 
 @hint(topics=[_('bodhi.update.request.unpush')])
 def bodhi_update_request_unpush(config, message):
-    """ Bodhi: a user requested an update be unpushed
+    """ Requests for Bodhi updates to be unpushed
 
     This rule will let through messages from the `Bodhi Updates System
     <https://admin.fedoraproject.org/updates>`_ indicating that a user has
@@ -102,7 +102,7 @@ def bodhi_update_request_unpush(config, message):
 
 @hint(topics=[_('bodhi.updates.epel.sync')])
 def bodhi_update_epel_sync(config, message):
-    """ Bodhi: new epel updates are synced out to mirror master
+    """ New EPEL content has hit the master mirror
 
     This rule will let through messages from the `Bodhi Updates System
     <https://admin.fedoraproject.org/updates>`_ when new epel updates are
@@ -113,7 +113,7 @@ def bodhi_update_epel_sync(config, message):
 
 @hint(topics=[_('bodhi.updates.fedora.sync')])
 def bodhi_update_fedora_sync(config, message):
-    """ Bodhi: new fedora updates are synced out to mirror master
+    """ New Fedora updates content has hit the master mirror
 
     This rule will let through messages from the `Bodhi Updates System
     <https://admin.fedoraproject.org/updates>`_ when new fedora updates are

--- a/fmn/rules/bugzilla.py
+++ b/fmn/rules/bugzilla.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('bugzilla.bug.new')])
 def bugzilla_bug_new(config, message):
-    """ Bugzilla: a user filed a new bug
+    """ New RHBZ bugs
 
     Adding this rule will trigger notifications when a user **files** a new bug
     in `Bugzilla <https://bugzilla.redhat.com>`_ for **Fedora** or **Fedora
@@ -14,7 +14,7 @@ def bugzilla_bug_new(config, message):
 
 @hint(topics=[_('bugzilla.bug.update')])
 def bugzilla_bug_update(config, message):
-    """ Bugzilla: a user updated a bug
+    """ Updates to existing RHBZ bugs
 
     Adding this rule will trigger notifications when a user **updates** a bug
     in `Bugzilla <https://bugzilla.redhat.com>`_ for **Fedora** or **Fedora

--- a/fmn/rules/buildsys.py
+++ b/fmn/rules/buildsys.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(categories=['buildsys'], invertible=False)
 def koji_instance(config, message, instance=None, *args, **kw):
-    """ Koji: pertains only to particular instances
+    """ Particular koji instances
 
     You may not have even known it, but we have multiple instances of the koji
     build system.  There is the **primary** buildsystem at
@@ -32,7 +32,7 @@ def koji_instance(config, message, instance=None, *args, **kw):
 
 @hint(topics=[_('buildsys.task.state.change')])
 def koji_scratch_build_state_change(config, message):
-    """ Koji: *scratch* build changed state (started, failed, finished)
+    """ Scratch builds changing state (any state)
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ about **scratch** build state
@@ -43,7 +43,7 @@ def koji_scratch_build_state_change(config, message):
 
 @hint(topics=[_('buildsys.task.state.change')], invertible=False)
 def koji_scratch_build_started(config, message):
-    """ Koji: *scratch* build started
+    """ Scratch builds starting
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime a
@@ -57,7 +57,7 @@ def koji_scratch_build_started(config, message):
 
 @hint(topics=[_('buildsys.task.state.change')], invertible=False)
 def koji_scratch_build_completed(config, message):
-    """ Koji: *scratch* build completed
+    """ Scratch builds completing
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime a
@@ -71,7 +71,7 @@ def koji_scratch_build_completed(config, message):
 
 @hint(topics=[_('buildsys.task.state.change')], invertible=False)
 def koji_scratch_build_failed(config, message):
-    """ Koji: *scratch* build failed
+    """ Scratch builds failing
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime a
@@ -85,7 +85,7 @@ def koji_scratch_build_failed(config, message):
 
 @hint(topics=[_('buildsys.task.state.change')], invertible=False)
 def koji_scratch_build_cancelled(config, message):
-    """ Koji: *scratch* build cancelled
+    """ Scratch builds being cancelled
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime a
@@ -99,7 +99,7 @@ def koji_scratch_build_cancelled(config, message):
 
 @hint(topics=[_('buildsys.build.state.change')])
 def koji_build_state_change(config, message):
-    """ Koji: build changed state (started, failed, finished)
+    """ Builds changing state (any state)
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime a
@@ -111,7 +111,7 @@ def koji_build_state_change(config, message):
 
 @hint(topics=[_('buildsys.build.state.change')], invertible=False)
 def koji_build_started(config, message):
-    """ Koji: build started
+    """ Builds starting
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime **a
@@ -125,7 +125,7 @@ def koji_build_started(config, message):
 
 @hint(topics=[_('buildsys.build.state.change')], invertible=False)
 def koji_build_completed(config, message):
-    """ Koji: build completed
+    """ Builds completing
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime **a
@@ -139,7 +139,7 @@ def koji_build_completed(config, message):
 
 @hint(topics=[_('buildsys.build.state.change')], invertible=False)
 def koji_build_deleted(config, message):
-    """ Koji: build deleted
+    """ Builds being deleted
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime **a
@@ -153,7 +153,7 @@ def koji_build_deleted(config, message):
 
 @hint(topics=[_('buildsys.build.state.change')], invertible=False)
 def koji_build_failed(config, message):
-    """ Koji: build failed
+    """ Builds failing
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime **a
@@ -167,7 +167,7 @@ def koji_build_failed(config, message):
 
 @hint(topics=[_('buildsys.build.state.change')], invertible=False)
 def koji_build_cancelled(config, message):
-    """ Koji: build cancelled
+    """ Builds being cancelled
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ that get published anytime **a
@@ -181,7 +181,7 @@ def koji_build_cancelled(config, message):
 
 @hint(topics=[_('buildsys.package.list.change')])
 def koji_package_list_change(config, message):
-    """ Koji: Package listing has changed
+    """ Koji "package list" changes
 
     This rule lets through messages from the `koji build
     system <https://koji.fedoraproject.org>`_ indicating that the package
@@ -192,7 +192,7 @@ def koji_package_list_change(config, message):
 
 @hint(topics=[_('buildsys.repo.done')])
 def koji_repo_done(config, message):
-    """ Koji: Building a repo has finished
+    """ Koji repo regeneration (complete)
 
     This rule lets through messages indicating that the `koji build
     system <https://koji.fedoraproject.org>`_ has **finished** rebuilding a
@@ -203,7 +203,7 @@ def koji_repo_done(config, message):
 
 @hint(topics=[_('buildsys.repo.init')])
 def koji_repo_init(config, message):
-    """ Koji: Building a repo has started
+    """ Koji repo regeneration (start)
 
     This rule lets through messages indicating that the `koji build
     system <https://koji.fedoraproject.org>`_ has **started** rebuilding a
@@ -214,7 +214,7 @@ def koji_repo_init(config, message):
 
 @hint(topics=[_('buildsys.tag')])
 def koji_tag(config, message):
-    """ Koji: A package has been tagged
+    """ Packages are added to a Koji tag
 
     This rule lets through messages that get published when the `koji build
     system <https://koji.fedoraproject.org>`_ applies a certain tag to a
@@ -225,7 +225,7 @@ def koji_tag(config, message):
 
 @hint(topics=[_('buildsys.untag')])
 def koji_untag(config, message):
-    """ Koji: A package has been untagged
+    """ Packages are removed from a Koji tag
 
     This rule lets through messages that get published when the `koji build
     system <https://koji.fedoraproject.org>`_ removes a tag from a

--- a/fmn/rules/compose.py
+++ b/fmn/rules/compose.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('compose.branched.complete')])
 def compose_branched_complete(config, message):
-    """ Release Engineering: Compose completed for a specific branch
+    """ Compose completed for a specific branch
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ completes
@@ -15,7 +15,7 @@ def compose_branched_complete(config, message):
 
 @hint(topics=[_('compose.branched.mash.complete')])
 def compose_branched_mash_complete(config, message):
-    """ Release Engineering: Mash completed for a specific branch
+    """ Mash completed for a specific branch
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ completes
@@ -28,7 +28,7 @@ def compose_branched_mash_complete(config, message):
 
 @hint(topics=[_('compose.branched.mash.start')])
 def compose_branched_mash_start(config, message):
-    """ Release Engineering: Mash started for a specific branch
+    """ Mash started for a specific branch
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ starts
@@ -41,7 +41,7 @@ def compose_branched_mash_start(config, message):
 
 @hint(topics=[_('compose.branched.pungify.complete')])
 def compose_branched_pungify_complete(config, message):
-    """ Release Engineering: Pungi completed for a specific branch
+    """ Pungi completed for a specific branch
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ completes
@@ -54,7 +54,7 @@ def compose_branched_pungify_complete(config, message):
 
 @hint(topics=[_('compose.branched.pungify.start')])
 def compose_branched_pungify_start(config, message):
-    """ Release Engineering: Pungi started for a specific branch
+    """ Pungi started for a specific branch
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ starts
@@ -67,7 +67,7 @@ def compose_branched_pungify_start(config, message):
 
 @hint(topics=[_('compose.branched.rsync.complete')])
 def compose_branched_rsync_complete(config, message):
-    """ Release Engineering: rsync completed for a specific branch
+    """ rsync completed for a specific branch
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ finishes
@@ -79,7 +79,7 @@ def compose_branched_rsync_complete(config, message):
 
 @hint(topics=[_('compose.branched.rsync.start')])
 def compose_branched_rsync_start(config, message):
-    """ Release Engineering: rsync started for a specific branch
+    """ rsync started for a specific branch
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ starts
@@ -91,7 +91,7 @@ def compose_branched_rsync_start(config, message):
 
 @hint(topics=[_('compose.branched.start')])
 def compose_branched_start(config, message):
-    """ Release Engineering: Compose started for a specific branch
+    """ Compose started for a specific branch
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ starts
@@ -103,7 +103,7 @@ def compose_branched_start(config, message):
 
 @hint(topics=[_('compose.epelbeta.complete')])
 def compose_epelbeta_complete(config, message):
-    """ Release Engineering: Compose completed for epelbeta
+    """ Compose completed for epelbeta
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ completes
@@ -115,7 +115,7 @@ def compose_epelbeta_complete(config, message):
 
 @hint(topics=[_('compose.rawhide.complete')])
 def compose_rawhide_complete(config, message):
-    """ Release Engineering: Compose completed for rawhide
+    """ Compose completed for rawhide
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ completes
@@ -127,7 +127,7 @@ def compose_rawhide_complete(config, message):
 
 @hint(topics=[_('compose.rawhide.mash.complete')])
 def compose_rawhide_mash_complete(config, message):
-    """ Release Engineering: Mash completed for rawhide
+    """ Mash completed for rawhide
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ completes
@@ -139,7 +139,7 @@ def compose_rawhide_mash_complete(config, message):
 
 @hint(topics=[_('compose.rawhide.mash.start')])
 def compose_rawhide_mash_start(config, message):
-    """ Release Engineering: Mash started for rawhide
+    """ Mash started for rawhide
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ starts
@@ -151,7 +151,7 @@ def compose_rawhide_mash_start(config, message):
 
 @hint(topics=[_('compose.rawhide.pungify.complete')])
 def compose_rawhide_pungify_complete(config, message):
-    """ Release Engineering: Pungi completed for rawhide
+    """ Pungi completed for rawhide
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ completes
@@ -163,7 +163,7 @@ def compose_rawhide_pungify_complete(config, message):
 
 @hint(topics=[_('compose.rawhide.pungify.start')])
 def compose_rawhide_pungify_start(config, message):
-    """ Release Engineering: Pungi started for rawhide
+    """ Pungi started for rawhide
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ starts
@@ -175,7 +175,7 @@ def compose_rawhide_pungify_start(config, message):
 
 @hint(topics=[_('compose.rawhide.rsync.complete')])
 def compose_rawhide_rsync_complete(config, message):
-    """ Release Engineering: rsync completed for rawhide
+    """ rsync completed for rawhide
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ finishes
@@ -187,7 +187,7 @@ def compose_rawhide_rsync_complete(config, message):
 
 @hint(topics=[_('compose.rawhide.rsync.start')])
 def compose_rawhide_rsync_start(config, message):
-    """ Release Engineering: rsync started for rawhide
+    """ rsync started for rawhide
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ starts
@@ -199,7 +199,7 @@ def compose_rawhide_rsync_start(config, message):
 
 @hint(topics=[_('compose.rawhide.start')])
 def compose_rawhide_start(config, message):
-    """ Release Engineering: Compose started for rawhide
+    """ Compose started for rawhide
 
     Adding this rule will allow through notifications published when `release
     engineering <https://fedoraproject.org/wiki/ReleaseEngineering>`_ starts

--- a/fmn/rules/coprs.py
+++ b/fmn/rules/coprs.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('copr.build.start')])
 def copr_build_start(config, message):
-    """ Copr:  Build started
+    """ Copr builds starting
 
     `Copr <https://fedorahosted.org/copr/>`_ publishes messages
     when a new build starts.  Adding this rule will get you those messages.
@@ -13,7 +13,7 @@ def copr_build_start(config, message):
 
 @hint(topics=[_('copr.build.end')])
 def copr_build_end(config, message):
-    """ Copr:  Build ended
+    """ Copr builds ending
 
     `Copr <https://fedorahosted.org/copr/>`_ publishes messages
     when a new build ends.  Adding this rule will get you those messages.
@@ -23,7 +23,7 @@ def copr_build_end(config, message):
 
 @hint(topics=[_('copr.build.end')], invertible=False)
 def copr_build_failed(config, message):
-    """ Copr:  Build failed
+    """ Copr builds failing
 
     `Copr <https://fedorahosted.org/copr/>`_ publishes messages
     when a new build fails.  Adding this rule will get you those messages.
@@ -36,7 +36,7 @@ def copr_build_failed(config, message):
 
 @hint(topics=[_('copr.build.end')], invertible=False)
 def copr_build_success(config, message):
-    """ Copr:  Build successfully ended
+    """ Copr builds succeeding
 
     `Copr <https://fedorahosted.org/copr/>`_ publishes messages
     when a new build successfully ends.  Adding this rule will get you those messages.
@@ -49,7 +49,7 @@ def copr_build_success(config, message):
 
 @hint(topics=[_('copr.build.end')], invertible=False)
 def copr_build_skipped(config, message):
-    """ Copr:  Build skipped
+    """ Copr builds skipped
 
     `Copr <https://fedorahosted.org/copr/>`_ publishes messages
     when a new build is skipped.  Adding this rule will get you those messages.
@@ -62,7 +62,7 @@ def copr_build_skipped(config, message):
 
 @hint(topics=[_('copr.chroot.start')])
 def copr_chroot_start(config, message):
-    """ Copr:  chroot started
+    """ New Copr chroots
 
     `Copr <https://fedorahosted.org/copr/>`_ publishes messages
     when a new chroot starts.  Adding this rule will get you those messages.
@@ -72,7 +72,7 @@ def copr_chroot_start(config, message):
 
 @hint(topics=[_('copr.worker.create')])
 def copr_worker_create(config, message):
-    """ Copr:  worker created
+    """ New Copr workers are spun up
 
     `Copr <https://fedorahosted.org/copr/>`_ publishes messages
     when a new worker is created.  Adding this rule will get you those

--- a/fmn/rules/fas.py
+++ b/fmn/rules/fas.py
@@ -47,7 +47,7 @@ def fas_group_member_sponsor(config, message):
 
 @hint(topics=[_('fas.group.update')])
 def fas_group_update(config, message):
-    """ FAS groups metadata changes
+    """ FAS groups information changes
 
     Adding this rule to a filter will allow through `Fedora Account System
     <https://admin.fedoraproject.org/accounts>`_ notifications indicating that

--- a/fmn/rules/fas.py
+++ b/fmn/rules/fas.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('fas.group.create')])
 def fas_group_create(config, message):
-    """ FAS: New group created
+    """ New FAS groups
 
     Adding this rule to a filter will allow through `Fedora Account System
     <https://admin.fedoraproject.org/accounts>`_ notifications indicating that
@@ -14,7 +14,7 @@ def fas_group_create(config, message):
 
 @hint(topics=[_('fas.group.member.apply')])
 def fas_group_member_apply(config, message):
-    """ FAS: A member requested to join a group
+    """ Members apply to FAS groups
 
     Adding this rule to a filter will allow through `Fedora Account System
     <https://admin.fedoraproject.org/accounts>`_ notifications indicating that
@@ -25,7 +25,7 @@ def fas_group_member_apply(config, message):
 
 @hint(topics=[_('fas.group.member.remove')])
 def fas_group_member_remove(config, message):
-    """ FAS: A user was removed from a group
+    """ Members are removed from FAS groups
 
     Adding this rule to a filter will allow through `Fedora Account System
     <https://admin.fedoraproject.org/accounts>`_ notifications indicating that
@@ -36,7 +36,7 @@ def fas_group_member_remove(config, message):
 
 @hint(topics=[_('fas.group.member.sponsor')])
 def fas_group_member_sponsor(config, message):
-    """ FAS: A user has been sponsored by an authorized user into a group
+    """ Members are sponsored in to FAS groups
 
     Adding this rule to a filter will allow through `Fedora Account System
     <https://admin.fedoraproject.org/accounts>`_ notifications indicating that
@@ -47,7 +47,7 @@ def fas_group_member_sponsor(config, message):
 
 @hint(topics=[_('fas.group.update')])
 def fas_group_update(config, message):
-    """ FAS: A group's properties have been modified
+    """ FAS groups metadata changes
 
     Adding this rule to a filter will allow through `Fedora Account System
     <https://admin.fedoraproject.org/accounts>`_ notifications indicating that
@@ -58,7 +58,7 @@ def fas_group_update(config, message):
 
 @hint(topics=[_('fas.role.update')])
 def fas_role_update(config, message):
-    """ FAS: A user's role in a particular group has been updated
+    """ Role changes for users in a FAS group
 
     Adding this rule to a filter will allow through `Fedora Account System
     <https://admin.fedoraproject.org/accounts>`_ notifications indicating that
@@ -69,7 +69,7 @@ def fas_role_update(config, message):
 
 @hint(topics=[_('fas.user.create')])
 def fas_user_create(config, message):
-    """ FAS: A new user account has been created
+    """ New FAS accounts
 
     Adding this rule to a filter will allow through `Fedora Account System
     <https://admin.fedoraproject.org/accounts>`_ notifications indicating that
@@ -80,7 +80,7 @@ def fas_user_create(config, message):
 
 @hint(topics=[_('fas.user.update')])
 def fas_user_update(config, message):
-    """ FAS: A user updated his/her account
+    """ Updates to FAS accounts
 
     Adding this rule to a filter will allow through `Fedora Account System
     <https://admin.fedoraproject.org/accounts>`_ notifications indicating that

--- a/fmn/rules/fedbadges.py
+++ b/fmn/rules/fedbadges.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('fedbadges.badge.award')])
 def fedbadges_badge_award(config, message):
-    """ New badge awards
+    """ New badge awards in the Fedora Badges system
 
     Adding this rule will let through notifications from the `Fedora Badges
     <https://badges.fedoraproject.org>`_ system whenever someone is *awarded a
@@ -25,7 +25,7 @@ def fedbadges_person_first_login(config, message):
 
 @hint(topics=[_('fedbadges.person.rank.advance')])
 def fedbadges_person_rank_advance(config, message):
-    """ Fedora Badges rank changes
+    """ Rank changes in the Fedora Badges system
 
     Adding this rule will let through notifications from the `Fedora Badges
     <https://badges.fedoraproject.org>`_ system whenever someone's *rank

--- a/fmn/rules/fedbadges.py
+++ b/fmn/rules/fedbadges.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('fedbadges.badge.award')])
 def fedbadges_badge_award(config, message):
-    """ Badges: A new badge has been awarded to someone
+    """ New badge awards
 
     Adding this rule will let through notifications from the `Fedora Badges
     <https://badges.fedoraproject.org>`_ system whenever someone is *awarded a
@@ -14,7 +14,7 @@ def fedbadges_badge_award(config, message):
 
 @hint(topics=[_('fedbadges.person.login.first')])
 def fedbadges_person_first_login(config, message):
-    """ Badges: Someone logs in for the first time
+    """ New people login to badges.fedoraproject.org
 
     Adding this rule will let through notifications from the `Fedora Badges
     <https://badges.fedoraproject.org>`_ system whenever someone *logs in*
@@ -25,7 +25,7 @@ def fedbadges_person_first_login(config, message):
 
 @hint(topics=[_('fedbadges.person.rank.advance')])
 def fedbadges_person_rank_advance(config, message):
-    """ Badges: The rank of someone changed on the badges leaderboard
+    """ Fedora Badges rank changes
 
     Adding this rule will let through notifications from the `Fedora Badges
     <https://badges.fedoraproject.org>`_ system whenever someone's *rank

--- a/fmn/rules/fedocal.py
+++ b/fmn/rules/fedocal.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('fedocal.calendar.clear')])
 def fedocal_calendar_clear(config, message):
-    """ Calendar:  An admin has cleared all meetings from a calendar.
+    """ When an admin has cleared all meetings from a calendar.
 
     Adding this rule will let through notifications from `Fedocal
     <https://apps.fedoraproject.org/calendar>`_ whenever someone clears all
@@ -14,7 +14,7 @@ def fedocal_calendar_clear(config, message):
 
 @hint(topics=[_('fedocal.calendar.new')])
 def fedocal_calendar_create(config, message):
-    """ Calendar:  An admin has created a new calendar.
+    """ New fedocal calendars
 
     Adding this rule will let through notifications from `Fedocal
     <https://apps.fedoraproject.org/calendar>`_ whenever someone creates a
@@ -25,7 +25,7 @@ def fedocal_calendar_create(config, message):
 
 @hint(topics=[_('fedocal.calendar.delete')])
 def fedocal_calendar_delete(config, message):
-    """ Calendar:  An admin has deleted a calendar.
+    """ Old fedocal calendars are deleted
 
     Adding this rule will let through notifications from `Fedocal
     <https://apps.fedoraproject.org/calendar>`_ whenever someone deletes a
@@ -36,7 +36,7 @@ def fedocal_calendar_delete(config, message):
 
 @hint(topics=[_('fedocal.calendar.update')])
 def fedocal_calendar_update(config, message):
-    """ Calendar:  An admin has updated a calendar.
+    """ Fedocal calendars get their metadata updated
 
     Adding this rule will let through notifications from `Fedocal
     <https://apps.fedoraproject.org/calendar>`_ whenever someone updates a
@@ -47,7 +47,7 @@ def fedocal_calendar_update(config, message):
 
 @hint(topics=[_('fedocal.meeting.new')])
 def fedocal_meeting_create(config, message):
-    """ Meeting:  Someone created a new meeting.
+    """ New meetings scheduled in fedocal
 
     Adding this rule will let through notifications from `Fedocal
     <https://apps.fedoraproject.org/meeting>`_ whenever someone creates a
@@ -58,7 +58,7 @@ def fedocal_meeting_create(config, message):
 
 @hint(topics=[_('fedocal.meeting.update')])
 def fedocal_meeting_update(config, message):
-    """ Meeting:  Someone updated a meeting.
+    """ Updated fedocal meetings
 
     Adding this rule will let through notifications from `Fedocal
     <https://apps.fedoraproject.org/meeting>`_ whenever someone updates an
@@ -69,7 +69,7 @@ def fedocal_meeting_update(config, message):
 
 @hint(topics=[_('fedocal.meeting.delete')])
 def fedocal_meeting_delete(config, message):
-    """ Meeting:  Someone deleted a meeting.
+    """ Old fedocal meetings are deleted
 
     Adding this rule will let through notifications from `Fedocal
     <https://apps.fedoraproject.org/meeting>`_ whenever someone deletes an
@@ -80,7 +80,7 @@ def fedocal_meeting_delete(config, message):
 
 @hint(topics=[_('fedocal.meeting.reminder')])
 def fedocal_meeting_reminder(config, message):
-    """ Meeting:  Automatic upcoming meeting reminders.
+    """ Fedocal meeting reminders
 
     Adding this rule will let through scheduled notifications from `Fedocal
     <https://apps.fedoraproject.org/meeting>`_ whenever a meeting is

--- a/fmn/rules/fedocal.py
+++ b/fmn/rules/fedocal.py
@@ -69,7 +69,7 @@ def fedocal_meeting_update(config, message):
 
 @hint(topics=[_('fedocal.meeting.delete')])
 def fedocal_meeting_delete(config, message):
-    """ Old fedocal meetings are deleted
+    """ Fedocal meetings are deleted
 
     Adding this rule will let through notifications from `Fedocal
     <https://apps.fedoraproject.org/meeting>`_ whenever someone deletes an

--- a/fmn/rules/fedora_elections.py
+++ b/fmn/rules/fedora_elections.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('fedora_elections.candidate.delete')])
 def fedora_elections_candidate_delete(config, message):
-    """ Elections: A candidate was deleted from an election.
+    """ Candidates are deleted from an election.
 
     Adding this rule will let through elections from `Fedora
     Elections <https://apps.fedoraproject.org/voting/>`_ whenever
@@ -14,7 +14,7 @@ def fedora_elections_candidate_delete(config, message):
 
 @hint(topics=[_('fedora_elections.candidate.edit')])
 def fedora_elections_candidate_edit(config, message):
-    """ Elections: A candidate was edited in an election.
+    """ Candidates are updated in an election.
 
     Adding this rule will let through elections from `Fedora
     Elections <https://apps.fedoraproject.org/voting/>`_ whenever a
@@ -25,7 +25,7 @@ def fedora_elections_candidate_edit(config, message):
 
 @hint(topics=[_('fedora_elections.candidate.new')])
 def fedora_elections_candidate_new(config, message):
-    """ Elections: A candidate is added to an election.
+    """ New candidates are added to an election.
 
     Adding this rule will let through elections from `Fedora
     Elections <https://apps.fedoraproject.org/voting/>`_ whenever a
@@ -36,18 +36,18 @@ def fedora_elections_candidate_new(config, message):
 
 @hint(topics=[_('fedora_elections.election.edit')])
 def fedora_elections_election_edit(config, message):
-    """ Elections: Someone edited an election.
+    """ Elections are updated
 
     Adding this rule will let through elections from `Fedora
     Elections <https://apps.fedoraproject.org/voting/>`_ whenever someone
-    edits an election.
+    edits the metadata of an election.
     """
     return message['topic'].endswith('fedora_elections.election.edit')
 
 
 @hint(topics=[_('fedora_elections.election.new')])
 def fedora_elections_election_new(config, message):
-    """ Elections: Someone created a new election.
+    """ New elections
 
     Adding this rule will let through elections from `Fedora
     Elections <https://apps.fedoraproject.org/voting/>`_ whenever someone

--- a/fmn/rules/fedoratagger.py
+++ b/fmn/rules/fedoratagger.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('fedoratagger.rating.update')])
 def fedoratagger_rating_update(config, message):
-    """ Tagger: The rating of a package has been updated
+    """ The rating changes on a package (fedora-tagger)
 
     Adding this rule to your filters will let through messages
     from `Fedora Tagger <https://apps.fedoraproject.org/tagger>`_
@@ -14,7 +14,7 @@ def fedoratagger_rating_update(config, message):
 
 @hint(topics=[_('fedoratagger.tag.create')])
 def fedoratagger_tag_create(config, message):
-    """ Tagger: A new tag has been added to a package
+    """ New tags on a package (fedora-tagger)
 
     Adding this rule to your filters will let through messages
     from `Fedora Tagger <https://apps.fedoraproject.org/tagger>`_
@@ -25,7 +25,7 @@ def fedoratagger_tag_create(config, message):
 
 @hint(topics=[_('fedoratagger.tag.update')])
 def fedoratagger_tag_update(config, message):
-    """ Tagger: Someone voted on a tag
+    """ Votes on a package tag (fedora-tagger)
 
     Adding this rule to your filters will let through messages
     from `Fedora Tagger <https://apps.fedoraproject.org/tagger>`_
@@ -36,7 +36,7 @@ def fedoratagger_tag_update(config, message):
 
 @hint(topics=[_('fedoratagger.usage.toggle')])
 def fedoratagger_usage_toggle(config, message):
-    """ Tagger: Someone marked that they use a package
+    """ Usage counts change on a package (fedora-tagger)
 
     Adding this rule to your filters will let through messages
     from `Fedora Tagger <https://apps.fedoraproject.org/tagger>`_
@@ -48,7 +48,7 @@ def fedoratagger_usage_toggle(config, message):
 
 @hint(topics=[_('fedoratagger.user.rank.update')])
 def fedoratagger_user_rank_update(config, message):
-    """ Tagger: Rank of an user in Fedora Tagger leaderboard was changed
+    """ Leaderboard changes (fedora-tagger)
 
     Adding this rule to your filters will let through messages
     from `Fedora Tagger <https://apps.fedoraproject.org/tagger>`_

--- a/fmn/rules/fmn_notifications.py
+++ b/fmn/rules/fmn_notifications.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('fmn.confirmation.update')])
 def fmn_confirmation_update(config, message):
-    """ Notifications: The status of confirmation changed
+    """ Confirmation status changes (FMN)
 
     Adding this rule to your filters will let through messages
     from `Notifications <https://apps.fedoraproject.org/notifications>`_
@@ -14,7 +14,7 @@ def fmn_confirmation_update(config, message):
 
 @hint(topics=[_('fmn.filter.update')])
 def fmn_filter_update(config, message):
-    """ Notifications: Someone updated one of their notification rules
+    """ Notification filter changes (FMN)
 
     Adding this rule to your filters will let through messages
     from `Notifications <https://apps.fedoraproject.org/notifications>`_
@@ -25,7 +25,7 @@ def fmn_filter_update(config, message):
 
 @hint(topics=[_('fmn.preference.update')])
 def fmn_preference_update(config, message):
-    """ Notifications: Someone updated their delivery details
+    """ Notification profile changes (FMN)
 
     Adding this rule to your filters will let through messages
     from `Notifications <https://apps.fedoraproject.org/notifications>`_

--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -70,7 +70,7 @@ def package_filter(config, message, package=None, *args, **kw):
 
 
 def package_regex_filter(config, message, pattern=None, *args, **kw):
-    """ A particular package regular expression
+    """ All packages matching a regular expression
 
     Use this rule to include messages that relate to packages that match
     particular regular expressions
@@ -85,7 +85,7 @@ def package_regex_filter(config, message, pattern=None, *args, **kw):
 
 
 def regex_filter(config, message, pattern=None, *args, **kw):
-    """ A particular regular expression
+    """ All messages matching a regular expression
 
     Use this rule to include messages that bear a certain pattern.
     This can be anything that appears anywhere in the message (for instance,

--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -9,7 +9,7 @@ from fmn.lib.hinting import hint
 
 
 def user_filter(config, message, fasnick=None, *args, **kw):
-    """ All messages for a certain user
+    """ A particular user
 
     Use this rule to include messages that are associated with a
     specific user.
@@ -21,7 +21,7 @@ def user_filter(config, message, fasnick=None, *args, **kw):
 
 
 def not_user_filter(config, message, fasnick=None, *args, **kw):
-    """ All messages not concerning one or more users
+    """ Everything except a particular user
 
     Use this rule to exclude messages that are associated with one or more
     users. Specify several users by separating them with a comma ','.
@@ -42,7 +42,7 @@ def not_user_filter(config, message, fasnick=None, *args, **kw):
 
 
 def user_package_filter(config, message, fasnick=None, *args, **kw):
-    """ All messages concerning user's packages
+    """ A particular user's packages
 
     This rule includes messages that relate to packages where the
     specified user has **commit** ACLs.
@@ -58,7 +58,7 @@ def user_package_filter(config, message, fasnick=None, *args, **kw):
 
 
 def package_filter(config, message, package=None, *args, **kw):
-    """ All messages pertaining to a certain package
+    """ A particular package
 
     Use this rule to include messages that relate to a certain package
     (*i.e., nethack*).
@@ -70,7 +70,7 @@ def package_filter(config, message, package=None, *args, **kw):
 
 
 def package_regex_filter(config, message, pattern=None, *args, **kw):
-    """ All messages pertaining to packages matching a given regex
+    """ A particular package regular expression
 
     Use this rule to include messages that relate to packages that match
     particular regular expressions
@@ -85,7 +85,7 @@ def package_regex_filter(config, message, pattern=None, *args, **kw):
 
 
 def regex_filter(config, message, pattern=None, *args, **kw):
-    """ All messages matching a given regex
+    """ A particular regular expression
 
     Use this rule to include messages that bear a certain pattern.
     This can be anything that appears anywhere in the message (for instance,
@@ -103,10 +103,10 @@ def regex_filter(config, message, pattern=None, *args, **kw):
 
 @hint(categories=['trac'], invertible=False)
 def trac_hosted_filter(config, message, project=None, *args, **kw):
-    """ Filter the messages for one or more fedorahosted projects
+    """ Particular fedorahosted projects
 
      Adding this rule allows you to get notifications for one or more
-     `fedorahosted <https://fedorahosted.org>`_ project. Specify multiple
+     `fedorahosted <https://fedorahosted.org>`_ projects. Specify multiple
      projects by separating them with a comma ','.
      """
     project = kw.get('project', project)

--- a/fmn/rules/git.py
+++ b/fmn/rules/git.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('git.branch')])
 def git_branch(config, message):
-    """ Git: A new branch has been created in the git of package
+    """ New dist-git branches for packages
 
     Include this rule to receive notifications of new branches being created
     for Fedora package git repos.
@@ -13,7 +13,7 @@ def git_branch(config, message):
 
 @hint(topics=[_('git.lookaside.new')])
 def git_lookaside_new(config, message):
-    """ Git: New sources have been uploaded to the "lookaside cache"
+    """ New tarballs uploaded to the lookaside cache
 
     Include this rule to receive notifications of of new sources being uploaded
     to the "lookaside cache" as when someone runs ``fedpkg new-sources
@@ -24,7 +24,7 @@ def git_lookaside_new(config, message):
 
 @hint(topics=[_('git.mass_branch.complete')])
 def git_mass_branch_complete(config, message):
-    """ Git: Mass branching process completed
+    """ Mass-branch completes
 
     There is a script called ``pkgdb2branch`` that gets run by an SCM
     admin, typically as part of the new package process.
@@ -37,7 +37,7 @@ def git_mass_branch_complete(config, message):
 
 @hint(topics=[_('git.mass_branch.start')])
 def git_mass_branch_start(config, message):
-    """Git: Mass branching process started
+    """ Mass-branch begins
 
     There is a script called ``pkgdb2branch`` that gets run by an SCM
     admin, typically as part of the new package process.
@@ -50,7 +50,7 @@ def git_mass_branch_start(config, message):
 
 @hint(topics=[_('git.pkgdb2branch.complete')])
 def git_pkgdb2branch_complete(config, message):
-    """Git: Process to set branches on a package completed
+    """ pkgdb2branch completes
 
     There is a script called ``pkgdb2branch`` that gets run by an SCM
     admin as part of the new package process.  Typically, when an `SCM Admin
@@ -67,7 +67,7 @@ def git_pkgdb2branch_complete(config, message):
 
 @hint(topics=[_('git.pkgdb2branch.start')])
 def git_pkgdb2branch_start(config, message):
-    """Git: Process to set branches on a package started
+    """ pkgdb2branch starts
 
     There is a script called ``pkgdb2branch`` that gets run by an SCM
     admin as part of the new package process.  Typically, when an `SCM Admin
@@ -83,7 +83,7 @@ def git_pkgdb2branch_start(config, message):
 
 @hint(topics=[_('git.receive')])
 def git_receive(config, message):
-    """ Git: Changes have been pushed onto the git of a package
+    """ Git pushes to dist-git
 
     Including this rule will produce notifications triggered when somebody runs
     ``fedpkg push`` on a package.

--- a/fmn/rules/github.py
+++ b/fmn/rules/github.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('github.commit_comment')])
 def github_commit_comment(config, message):
-    """ Github: Someone commented directly on a commit
+    """ Commit comments (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -14,7 +14,7 @@ def github_commit_comment(config, message):
 
 @hint(topics=[_('github.create')])
 def github_create(config, message):
-    """ Github: Someone created a new tag or branch
+    """ New tags and branches (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -25,7 +25,7 @@ def github_create(config, message):
 
 @hint(topics=[_('github.delete')])
 def github_delete(config, message):
-    """ Github: Someone deleted a tag or branch
+    """ Deleted tags and branches (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -36,7 +36,7 @@ def github_delete(config, message):
 
 @hint(topics=[_('github.fork')])
 def github_fork(config, message):
-    """ Github: Someone forked a repo
+    """ Forked repos (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -47,7 +47,7 @@ def github_fork(config, message):
 
 @hint(topics=[_('github.issue.comment')])
 def github_issue_comment(config, message):
-    """ Github: Someone commented on an issue
+    """ Issue comments (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -58,7 +58,7 @@ def github_issue_comment(config, message):
 
 @hint(topics=[_('github.issue.reopened')])
 def github_issue_reopened(config, message):
-    """ Github: Someone changed an issue
+    """ Reopened issues (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -69,7 +69,7 @@ def github_issue_reopened(config, message):
 
 @hint(topics=[_('github.pull_request.closed')])
 def github_pull_request_closed(config, message):
-    """ Github: Someone closed an existing pull request
+    """ Closed pull-requests (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -80,7 +80,7 @@ def github_pull_request_closed(config, message):
 
 @hint(topics=[_('github.pull_request_review_comment')])
 def github_pull_request_review_comment(config, message):
-    """ Github: Someone commented on a pull request
+    """ Pull-request review comments (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -91,7 +91,7 @@ def github_pull_request_review_comment(config, message):
 
 @hint(topics=[_('github.push')])
 def github_push(config, message):
-    """ Github: Someone pushed to a github repo
+    """ Git pushes (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -102,7 +102,7 @@ def github_push(config, message):
 
 @hint(topics=[_('github.status')])
 def github_status(config, message):
-    """ Github: CI service updated the status of new commit
+    """ Continuous integration status (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -114,7 +114,7 @@ def github_status(config, message):
 
 @hint(topics=[_('github.watch')])
 def github_watch(config, message):
-    """ Github: Someone started watching a repository
+    """ Users watching repos (github.com)
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_
@@ -125,7 +125,7 @@ def github_watch(config, message):
 
 @hint(topics=[_('github.webhook')])
 def github_webhook(config, message):
-    """ Github: Someone enabled hook for fedmsg broadcast on a repository
+    """ New github repos on the fedmsg bus
 
     Adding this rule to your filters will let through messages
     from `Github <https://apps.fedoraproject.org/github2fedmsg>`_

--- a/fmn/rules/jenkins.py
+++ b/fmn/rules/jenkins.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('jenkins.build.aborted')])
 def jenkins_build_aborted(config, message):
-    """ Jenkins: A build has been aborted
+    """ Jenkins builds abort
 
     Adding this rule to your filters will let through messages
     from `Jenkins <http://jenkins.cloud.fedoraproject.org/>`_
@@ -14,7 +14,7 @@ def jenkins_build_aborted(config, message):
 
 @hint(topics=[_('jenkins.build.failed')])
 def jenkins_build_failed(config, message):
-    """ Jenkins: A build has failed
+    """ Jenkins builds that fail
 
     Adding this rule to your filters will let through messages
     from `Jenkins <http://jenkins.cloud.fedoraproject.org/>`_
@@ -25,7 +25,7 @@ def jenkins_build_failed(config, message):
 
 @hint(topics=[_('jenkins.build.notbuilt')])
 def jenkins_build_notbuilt(config, message):
-    """ Jenkins: A build was not built
+    """ Jenkins builds that become "notbuilt"
 
     Adding this rule to your filters will let through messages
     from `Jenkins <http://jenkins.cloud.fedoraproject.org/>`_
@@ -36,7 +36,7 @@ def jenkins_build_notbuilt(config, message):
 
 @hint(topics=[_('jenkins.build.passed')])
 def jenkins_build_passed(config, message):
-    """ Jenkins: A build was completed successfully
+    """ Jenkins builds that finish
 
     Adding this rule to your filters will let through messages
     from `Jenkins <http://jenkins.cloud.fedoraproject.org/>`_
@@ -47,7 +47,7 @@ def jenkins_build_passed(config, message):
 
 @hint(topics=[_('jenkins.build.start')])
 def jenkins_build_start(config, message):
-    """ Jenkins: A build has started
+    """ Jenkins builds starting
 
     Adding this rule to your filters will let through messages
     from `Jenkins <http://jenkins.cloud.fedoraproject.org/>`_
@@ -58,7 +58,7 @@ def jenkins_build_start(config, message):
 
 @hint(topics=[_('jenkins.build.unstable')])
 def jenkins_build_unstable(config, message):
-    """ Jenkins: A build has completed with warnings
+    """ Jenkins builds that finish with warnings
 
     Adding this rule to your filters will let through messages
     from `Jenkins <http://jenkins.cloud.fedoraproject.org/>`_

--- a/fmn/rules/kerneltest.py
+++ b/fmn/rules/kerneltest.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('kerneltest.release.edit')])
 def kerneltest_release_edit(config, message):
-    """ Kernel Test: An admin edited an existing release
+    """ An admin edits an existing release (kerneltest)
 
     Adding this rule to your filters will let through messages
     from `Kernel Test <https://apps.fedoraproject.org/kerneltest>`_
@@ -14,7 +14,7 @@ def kerneltest_release_edit(config, message):
 
 @hint(topics=[_('kerneltest.release.new')])
 def kerneltest_release_new(config, message):
-    """ Kernel Test: An admin did set up an existing release
+    """ An admin adds a new release (kerneltest)
 
     Adding this rule to your filters will let through messages
     from `Kernel Test <https://apps.fedoraproject.org/kerneltest>`_
@@ -25,7 +25,7 @@ def kerneltest_release_new(config, message):
 
 @hint(topics=[_('kerneltest.upload.new')])
 def kerneltest_upload_new(config, message):
-    """ Kernel Test: A new test result was uploaded
+    """ New kerneltest test results
 
     Adding this rule to your filters will let through messages
     from `Kernel Test <https://apps.fedoraproject.org/kerneltest>`_

--- a/fmn/rules/koschei.py
+++ b/fmn/rules/koschei.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('koschei.package.state.change')])
 def koschei_package_state_change(config, message):
-    """ Koschei: Package state has changed
+    """ Continuous integration state changes for a package (koschei)
 
     `Koschei <http://koschei.cloud.fedoraproject.org>`_ publishes this
     message when package's build or resolution state changes.
@@ -13,7 +13,7 @@ def koschei_package_state_change(config, message):
 
 @hint(categories=['koschei'], invertible=False)
 def koschei_group(config, message, group=None):
-    """ Koschei: Messages pertaining to a package in given groups
+    """ Particular Koschei package groups
 
     This rule limits message to particular
     `Koschei <http://koschei.cloud.fedoraproject.org>`_ groups. You can

--- a/fmn/rules/logger.py
+++ b/fmn/rules/logger.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('logger.log')])
 def logger_log(config, message):
-    """ Logger: Triggered by the default `fedmsg-logger` configuration.
+    """ Admin logging and debug statements
 
     Include this rule to receive notifications of messages being sent by an
     admin who uses `fedmsg-logger` on a host, and doesn't explicitly provide

--- a/fmn/rules/mailman.py
+++ b/fmn/rules/mailman.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('mailman.receive')])
 def mailman_receive(config, message):
-    """ Mailman: An email has been sent to a mailing list
+    """ Mailing list emails
 
     Including this rule will trigger a notification anytime
     an **email is posted** to any Fedora Project **mailman3** list.

--- a/fmn/rules/meetbot.py
+++ b/fmn/rules/meetbot.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('meetbot.meeting.complete')])
 def meetbot_meeting_complete(config, message):
-    """ Meetbot: Meeting completed
+    """ IRC meetings ending
 
     Trusty old `zodbot <https://meetbot.fedoraproject.org/>`_ publishes
     messages too!  Adding this rule will notify you when an IRC meeting
@@ -14,7 +14,7 @@ def meetbot_meeting_complete(config, message):
 
 @hint(topics=[_('meetbot.meeting.start')])
 def meetbot_meeting_start(config, message):
-    """ Meetbot: Meeting started
+    """ IRC meetings starting
 
     Trusty old `zodbot <https://meetbot.fedoraproject.org/>`_ publishes
     messages too!  Adding this rule will notify you (perhaps obviously)
@@ -25,7 +25,7 @@ def meetbot_meeting_start(config, message):
 
 @hint(topics=[_('meetbot.meeting.topic.update')])
 def meetbot_meeting_topic_update(config, message):
-    """ Meetbot: Topic of a meeting changed
+    """ IRC meeting topic changes
 
     As IRC meetings chug along, the chairperson may change the meeting;
     zodbot publishes message for that!  Guess what?  Adding this rule will let

--- a/fmn/rules/nuancier.py
+++ b/fmn/rules/nuancier.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('nuancier.candidate.approved')])
 def nuancier_candidate_approved(config, message):
-    """ Nuancier: An admin approved a candidate submission
+    """ Approved wallpaper candidates
 
     Adding this rule to your filters will let through messages
     from `Nuancier <https://apps.fedoraproject.org/nuancier>`_
@@ -14,7 +14,7 @@ def nuancier_candidate_approved(config, message):
 
 @hint(topics=[_('nuancier.candidate.denied')])
 def nuancier_candidate_denied(config, message):
-    """ Nuancier: An admin denied a candidate submission
+    """ Denied wallpaper candidates
 
     Adding this rule to your filters will let through messages
     from `Nuancier <https://apps.fedoraproject.org/nuancier>`_
@@ -25,7 +25,7 @@ def nuancier_candidate_denied(config, message):
 
 @hint(topics=[_('nuancier.candidate.new')])
 def nuancier_candidate_new(config, message):
-    """ Nuancier: A contributor submitted a new candidate
+    """ New wallpaper candidates
 
     Adding this rule to your filters will let through messages
     from `Nuancier <https://apps.fedoraproject.org/nuancier>`_
@@ -36,7 +36,7 @@ def nuancier_candidate_new(config, message):
 
 @hint(topics=[_('nuancier.election.new')])
 def nuancier_election_new(config, message):
-    """ Nuancier: An admin created a new election
+    """ New wallpaper elections are set up
 
     Adding this rule to your filters will let through messages
     from `Nuancier <https://apps.fedoraproject.org/nuancier>`_
@@ -47,7 +47,7 @@ def nuancier_election_new(config, message):
 
 @hint(topics=[_('nuancier.election.update')])
 def nuancier_election_update(config, message):
-    """ Nuancier: An admin updated details of a election
+    """ Existing wallpaper elections are modified
 
     Adding this rule to your filters will let through messages
     from `Nuancier <https://apps.fedoraproject.org/nuancier>`_

--- a/fmn/rules/pkgdb.py
+++ b/fmn/rules/pkgdb.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('pkgdb.acl.update')])
 def pkgdb_acl_update(config, message):
-    """ Pkgdb: a user updated an ACL
+    """ Package ACL updates
 
     Adding this rule will trigger notifications when an ACL on a package
     is **updated** in the Fedora `Package DB
@@ -14,7 +14,7 @@ def pkgdb_acl_update(config, message):
 
 @hint(topics=[_('pkgdb.acl.delete')])
 def pkgdb_acl_delete(config, message):
-    """ Pkgdb: a user deleted an ACL
+    """ Package ACLs are deleted
 
     Adding this rule will trigger notifications when an ACL on a package
     is **deleted** in the Fedora `Package DB
@@ -25,7 +25,7 @@ def pkgdb_acl_delete(config, message):
 
 @hint(topics=[_('pkgdb.admin.action.status.update')])
 def pkgdb_admin_action_status_update(config, message):
-    """ Pkgdb: an admin updated the status of Admin Action.
+    """ Pkgdb admin actions
 
     Adding this rule will trigger notifications when an admin **updates**
     the status of Admin Action in the Fedora `Package DB
@@ -36,7 +36,7 @@ def pkgdb_admin_action_status_update(config, message):
 
 @hint(topics=[_('pkgdb.branch.complete')])
 def pkgdb_branch_complete(config, message):
-    """ Pkgdb: finished the branching process
+    """ Pkgdb branching process completes
 
     Adding this rule will trigger notifications when the **branching process
     completes** for a package in the Fedora `Package DB
@@ -47,7 +47,7 @@ def pkgdb_branch_complete(config, message):
 
 @hint(topics=[_('pkgdb.branch.start')])
 def pkgdb_branch_start(config, message):
-    """ Pkgdb: started the branching process
+    """ Pkgdb branching process starts
 
     Adding this rule will trigger notifications when the **branching process
     starts** for a package in the Fedora `Package DB
@@ -58,7 +58,7 @@ def pkgdb_branch_start(config, message):
 
 @hint(topics=[_('pkgdb.collection.new')])
 def pkgdb_collection_new(config, message):
-    """ Pkgdb: new collection created
+    """ New pkgdb collections
 
     Adding this rule will trigger notifications when an admin **creates
     a new collection** in the Fedora `Package DB
@@ -69,7 +69,7 @@ def pkgdb_collection_new(config, message):
 
 @hint(topics=[_('pkgdb.collection.update')])
 def pkgdb_collection_update(config, message):
-    """ Pkgdb: a collection has been updated
+    """ Updates to pkgdb collections
 
     Adding this rule will trigger notifications when an admin **updates
     a collection** in the Fedora `Package DB
@@ -80,7 +80,7 @@ def pkgdb_collection_update(config, message):
 
 @hint(topics=[_('pkgdb.owner.update')])
 def pkgdb_owner_update(config, message):
-    """ Pkgdb: a user updated the owner of a package
+    """ Package owner changes
 
     Adding this rule will trigger notifications when the **owner** of a package
     in the Fedora `Package DB <https://admin.fedoraproject.org/pkgdb>`_
@@ -91,7 +91,7 @@ def pkgdb_owner_update(config, message):
 
 @hint(topics=[_('pkgdb.package.branch.delete')])
 def pkgdb_package_branch_delete(config, message):
-    """ Pkgdb: an admin deleted a branch of a package
+    """ Package branches are deleted
 
     Adding this rule will trigger notifications when an admin **deletes**
     a branch of a package in the Fedora `Package DB
@@ -102,7 +102,7 @@ def pkgdb_package_branch_delete(config, message):
 
 @hint(topics=[_('pkgdb.package.branch.new')])
 def pkgdb_package_branch_new(config, message):
-    """ Pkgdb: a new branch is created for a package
+    """ New package branches
 
     Adding this rule will trigger notifications when a **new branch** is
     **created** for a package in the Fedora `Package DB
@@ -113,7 +113,7 @@ def pkgdb_package_branch_new(config, message):
 
 @hint(topics=[_('pkgdb.package.branch.request')])
 def pkgdb_package_branch_request(config, message):
-    """ Pkgdb: a user requested a new branch for a package
+    """ Requests for new package branches
 
     Adding this rule will trigger notifications when a user **requests** a
     **new branch** for a package in the Fedora `Package DB
@@ -124,7 +124,7 @@ def pkgdb_package_branch_request(config, message):
 
 @hint(topics=[_('pkgdb.package.new')])
 def pkgdb_package_new(config, message):
-    """ Pkgdb: a new package has been created
+    """ New packages
 
     Adding this rule will trigger notifications when a **new package is
     created** in the Fedora `Package DB
@@ -137,7 +137,7 @@ def pkgdb_package_new(config, message):
 
 @hint(topics=[_('pkgdb.package.critpath.update')])
 def pkgdb_package_critpath_update(config, message):
-    """ Pkgdb: an admin updated the critpath flag
+    """ Critical path status changes
 
     Adding this rule will trigger notifications when **the critical path
     flag** of a package in the Fedora `Package DB
@@ -148,7 +148,7 @@ def pkgdb_package_critpath_update(config, message):
 
 @hint(topics=[_('pkgdb.package.delete')])
 def pkgdb_package_delete(config, message):
-    """ Pkgdb: an admin deleted a package
+    """ Deleted packages
 
     Adding this rule will trigger notifications when an admin **deletes** a
     package in the Fedora `Package DB
@@ -159,7 +159,7 @@ def pkgdb_package_delete(config, message):
 
 @hint(topics=[_('pkgdb.package.monitor.update')])
 def pkgdb_package_monitor_update(config, message):
-    """ Pkgdb: an admin updated monitoring status
+    """ Changes to the upstream-release-monitoring status of packages
 
     Adding this rule will trigger notifications when an admin **updates**
     **monitoring status** for a package in the Fedora `Package DB
@@ -170,7 +170,7 @@ def pkgdb_package_monitor_update(config, message):
 
 @hint(topics=[_('pkgdb.package.new.request')])
 def pkgdb_package_new_request(config, message):
-    """ Pkgdb: a user requested a new package
+    """ Requests for new packages
 
     Adding this rule will trigger notifications when a user **requests** a
     **new package** to be added in the Fedora `Package DB
@@ -181,7 +181,7 @@ def pkgdb_package_new_request(config, message):
 
 @hint(topics=[_('pkgdb.package.update')])
 def pkgdb_package_update(config, message):
-    """ Pkgdb: a user updated information about a package
+    """ Changes to package details
 
     Adding this rule will trigger notifications when a **package's details are
     updated** in the Fedora `Package DB
@@ -192,7 +192,7 @@ def pkgdb_package_update(config, message):
 
 @hint(topics=[_('pkgdb.package.update.status')])
 def pkgdb_package_update_status(config, message):
-    """ Pkgdb: a user updated the status of a package
+    """ Package status changes
 
     Adding this rule will trigger notifications when a **package's status is
     updated** in the Fedora `Package DB

--- a/fmn/rules/planet.py
+++ b/fmn/rules/planet.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('planet.post.new')])
 def planet_post_new(config, message):
-    """ Planet: A user posted on the Fedora planet
+    """ New blog posts on the Fedora Planet
 
     Yes, yes.. you could always use an RSS reader... but if you add *this* rule
     to your filter, you'll get notifications when new posts appear on the

--- a/fmn/rules/summershum.py
+++ b/fmn/rules/summershum.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('summershum.ingest.start')])
 def summershum_ingest_start(config, message):
-    """ Summershum: Started ingesting a tarball
+    """ Summershum starts ingesting a tarball
 
     Adding this rule to your filters will let through messages
     from `summershum <https://github.com/fedora-infra/summershum>`_
@@ -14,7 +14,7 @@ def summershum_ingest_start(config, message):
 
 @hint(topics=[_('summershum.ingest.fail')])
 def summershum_ingest_fail(config, message):
-    """ Summershum: failed to ingest a tarball
+    """ Summershum fails to ingest a tarball
 
     Adding this rule to your filters will let through messages
     from `summershum <https://github.com/fedora-infra/summershum>`_
@@ -25,7 +25,7 @@ def summershum_ingest_fail(config, message):
 
 @hint(topics=[_('summershum.ingest.complete')])
 def summershum_ingest_complete(config, message):
-    """ Summershum: finished ingesting a tarball
+    """ Summershum finishes ingesting a tarball
 
     Adding this rule to your filters will let through messages
     from `summershum <https://github.com/fedora-infra/summershum>`_

--- a/fmn/rules/trac.py
+++ b/fmn/rules/trac.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('trac.git.receive')])
 def trac_git_receive(config, message):
-    """ Fedora Hosted: Commits pushed to a git repository
+    """ Git pushes (fedorahosted.org)
 
     Adding this rule will get you notifications when a user **pushes commits**
     to a `fedorahosted <https://fedorahosted.org>`_ git repository.
@@ -13,7 +13,7 @@ def trac_git_receive(config, message):
 
 @hint(topics=[_('trac.ticket.delete')])
 def trac_ticket_delete(config, message):
-    """ Fedora Hosted: Deleted a ticket on a trac instance
+    """ Deleted trac tickets (fedorahosted.org)
 
     Adding this rule will get you notifications when a user **deletes a
     ticket** from a `fedorahosted <https://fedorahosted.org>`_ trac instance.
@@ -23,7 +23,7 @@ def trac_ticket_delete(config, message):
 
 @hint(topics=[_('trac.ticket.new')])
 def trac_ticket_new(config, message):
-    """ Fedora Hosted: Created a new ticket on a trac instance
+    """ New trac tickets (fedorahosted.org)
 
     Adding this rule will get you notifications when a user **creates a
     ticket** on a `fedorahosted <https://fedorahosted.org>`_ trac instance.
@@ -33,7 +33,7 @@ def trac_ticket_new(config, message):
 
 @hint(topics=[_('trac.ticket.update')])
 def trac_ticket_update(config, message):
-    """ Fedora Hosted: Updated a ticket on a trac instance
+    """ Updates to trac tickets (fedorahosted.org)
 
     Adding this rule will get you notifications when a user **updates a
     ticket** on a `fedorahosted <https://fedorahosted.org>`_ trac instance.
@@ -43,7 +43,7 @@ def trac_ticket_update(config, message):
 
 @hint(topics=[_('trac.wiki.page.delete')])
 def trac_wiki_page_delete(config, message):
-    """ Fedora Hosted: Deleted a wiki page of a trac instance
+    """ Deleted pages from trac wikis (fedorahosted.org)
 
     Adding this rule will get you notifications when a user **deletes a wiki
     page** on a `fedorahosted <https://fedorahosted.org>`_ trac instance.
@@ -53,7 +53,7 @@ def trac_wiki_page_delete(config, message):
 
 @hint(topics=[_('trac.wiki.page.new')])
 def trac_wiki_page_new(config, message):
-    """ Fedora Hosted: Created a wiki page of a trac instance
+    """ New pages on trac wikis (fedorahosted.org)
 
     Adding this rule will get you notifications when a user **creates a wiki
     page** on a `fedorahosted <https://fedorahosted.org>`_ trac instance.
@@ -63,7 +63,7 @@ def trac_wiki_page_new(config, message):
 
 @hint(topics=[_('trac.wiki.page.rename')])
 def trac_wiki_page_rename(config, message):
-    """ Fedora Hosted: Renamed a wiki page of a trac instance
+    """ Renames of trac wiki pages (fedorahosted.org)
 
     Adding this rule will get you notifications when a user **renames a wiki
     page** on a `fedorahosted <https://fedorahosted.org>`_ trac instance.
@@ -73,7 +73,7 @@ def trac_wiki_page_rename(config, message):
 
 @hint(topics=[_('trac.wiki.page.update')])
 def trac_wiki_page_update(config, message):
-    """ Fedora Hosted: Updated a wiki page of a trac instance
+    """ Updates to trac wiki pages (fedorahosted.org)
 
     Adding this rule will get you notifications when a user **updates a wiki
     page** on a `fedorahosted <https://fedorahosted.org>`_ trac instance.
@@ -83,7 +83,7 @@ def trac_wiki_page_update(config, message):
 
 @hint(topics=[_('trac.wiki.page.version.delete')])
 def trac_wiki_page_version_delete(config, message):
-    """ Fedora Hosted: Deleted a version of a wiki page
+    """ Old version of trac wiki pages are deleted (fedorahosted.org)
 
     Adding this rule will get you notifications when a user **deletes a version
     of a wiki page** on a `fedorahosted <https://fedorahosted.org>`_ trac

--- a/fmn/rules/wiki.py
+++ b/fmn/rules/wiki.py
@@ -3,7 +3,7 @@ from fmn.lib.hinting import hint, prefixed as _
 
 @hint(topics=[_('wiki.article.edit')])
 def wiki_article_edit(config, message):
-    """ Wiki: A user edited a wiki page
+    """ Wiki edits
 
     Fedora's `Wiki <https://fedoraproject.org/wiki>`_ has a fedmsg hook
     that publishes messages when a user **edits a page**.  Adding this rule
@@ -14,7 +14,7 @@ def wiki_article_edit(config, message):
 
 @hint(topics=[_('wiki.upload.complete')])
 def wiki_upload_complete(config, message):
-    """ Wiki: A user uploaded content on the wiki
+    """ Wiki media uploads
 
     Fedora's `Wiki <https://fedoraproject.org/wiki>`_ has a fedmsg hook
     that publishes messages when a user **uploads some media** (like a video or


### PR DESCRIPTION
It used to be that all the short-descriptions of the rules in the web ui
appeared very formal.  They were prefixed with some identifier like
"Fedora Hosted: ....".

This changeset tries to make them a little less formal and a little more
human-readable.  The long descriptions are still present so users can
click on them to get more info.

The intent is to have the UI read more fluidly like this:

- *Include* A particular user's packages (ralph's)
- *Include* Build state changes
- *Ignore*  Builds starting