### PR TITLE
Avoid calling pkgdb when we don't have to.

### DIFF
--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -50,9 +50,15 @@ def user_package_filter(config, message, fasnick=None, *args, **kw):
 
     fasnick = kw.get('fasnick', fasnick)
     if fasnick:
-        packages = fmn.rules.utils.get_packages_of_user(config, fasnick)
         msg_packages = fedmsg.meta.msg2packages(message, **config)
-        return packages.intersection(msg_packages)
+        if not msg_packages:
+            # If the message has no packages associated with it, there's no
+            # way that "one of them" is going to happen to belong to this user,
+            # so let's not waste our time doing the somewhat expensive call out
+            # to pkgdb on the next line to check.
+            return False
+        usr_packages = fmn.rules.utils.get_packages_of_user(config, fasnick)
+        return usr_packages.intersection(msg_packages)
 
     return False
 


### PR DESCRIPTION
If a message has no packages associated with it, there's no way that "one of
them" is going to happen to belong to a user, so don't waste time doing the
somewhat expensive call out to pkgdb.