### PR TITLE
Order of operations matters.

### DIFF
--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -44,7 +44,7 @@ def not_user_filter(config, message, fasnick=None, *args, **kw):
     if not fasnick:
         return False
 
-    fasnick = fasnick or [] and fasnick.split(',')
+    fasnick = (fasnick or []) and fasnick.split(',')
     valid = True
     for nick in fasnick:
         if nick.strip() in fedmsg.meta.msg2usernames(message, **config):


### PR DESCRIPTION
Here, this was turning 'pingou' into ['p', 'i', 'n', 'g', 'o', 'u'].

This should fix fedora-infra/fmn#58.