### PR TITLE
Disambiguate git messages.

### DIFF
--- a/fmn/rules/git.py
+++ b/fmn/rules/git.py
@@ -18,7 +18,7 @@ def git_branch(config, message):
     Include this rule to receive notifications of new branches being created
     for Fedora package git repos.
     """
-    return message['topic'].endswith('git.branch')
+    return message['topic'] == _('git.branch')
 
 
 @hint(topics=[_('git.lookaside.new')])
@@ -98,4 +98,4 @@ def git_receive(config, message):
     Including this rule will produce notifications triggered when somebody runs
     ``fedpkg push`` on a package.
     """
-    return message['topic'].endswith('git.receive')
+    return message['topic'] == _('git.receive')


### PR DESCRIPTION
Currently, the rule for ``git.receive`` also matches ``trac.git.receive`` which
is sending fedorahosted messages to the scm-commits list.  This should check
that the fully qualified topic matches.