### PR TITLE
Add watchcommits/watchbugs to the package-ownership fmn rule.

### DIFF
--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -148,7 +148,10 @@ def _get_pkgdb2_packages_for(config, username):
 
     data = req.json()
 
-    packages_of_interest = data['point of contact'] + data['co-maintained']
+    packages_of_interest = \
+        data['point of contact'] + \
+        data['co-maintained'] + \
+        data['watch']
     packages_of_interest = set([p['name'] for p in packages_of_interest])
     log.debug("done talking with pkgdb2 for now.  %0.2fs", time.time() - start)
     return packages_of_interest


### PR DESCRIPTION
We need something like this to let the perl-sig user catch all the packages
that it watches to forward things to the perl-devel list.