### PR TITLE
Ditch old re2 warning hook.

### DIFF
--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -12,7 +12,6 @@ log = logging.getLogger('fedmsg')
 
 try:
     import re2 as re
-    re.set_fallback_notification(re.FALLBACK_WARNING)
 except ImportError:
     log.warning("Couldn't import the 're2' module.")
     import re

--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -182,8 +182,8 @@ def package_regex_filter(config, message, pattern=None, *args, **kw):
     pattern = kw.get('pattern', pattern)
     if pattern:
         packages = fedmsg.meta.msg2packages(message, **config)
-        regex = re.compile(pattern)
-        return any([regex.search(package) for package in packages])
+        regex = re.compile(pattern.encode('utf-8'))
+        return any([regex.search(p.encode('utf-8')) for p in packages])
 
 
 # Can't hint this one.  Can't pass a regex on to postgres
@@ -200,7 +200,7 @@ def regex_filter(config, message, pattern=None, *args, **kw):
 
     pattern = kw.get('pattern', pattern)
     if pattern:
-        regex = re.compile(pattern)
+        regex = re.compile(pattern.encode('utf-8'))
         return bool(regex.search(fedmsg.encoding.dumps(message['msg'])))
 
 


### PR DESCRIPTION
Google has a regular expression lib in C called 're2'.

There are multiple python bindings for it out there.  We used to use the one by
axiak, called pyre2 on pypi.  At PyCon, I learned that his bindings are
unmaintained, incomplete, and incorrect.  They just so happened to work for the
case we were using it for in fmn.rules, so we didn't notice.

Facebook engineers maintain a more up-to-date set of python bindings called
fb-re2 on pypi.  They approached us at PyCon and we swapped out the old pyre2
for fb-re2 in the ``python-re2`` module in EPEL and Fedora.

Anyways.. we're updated to that new fb-re2 source and it doesn't produce this
little warning function that we were calling, so just drop it.