### PR TITLE
Cache slow python-re2 compilation.

### DIFF
--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -7,16 +7,6 @@ import fmn.rules.utils
 from fmn.lib.hinting import hint
 
 
-import logging
-log = logging.getLogger('fedmsg')
-
-try:
-    import re2 as re
-except ImportError:
-    log.warning("Couldn't import the 're2' module.")
-    import re
-
-
 @hint(callable=lambda config, fasnick: dict(users=[fasnick]))
 def user_filter(config, message, fasnick=None, *args, **kw):
     """ A particular user
@@ -182,7 +172,7 @@ def package_regex_filter(config, message, pattern=None, *args, **kw):
     pattern = kw.get('pattern', pattern)
     if pattern:
         packages = fedmsg.meta.msg2packages(message, **config)
-        regex = re.compile(pattern.encode('utf-8'))
+        regex = fmn.rules.utils.compile_regex(pattern.encode('utf-8'))
         return any([regex.search(p.encode('utf-8')) for p in packages])
 
 
@@ -200,7 +190,7 @@ def regex_filter(config, message, pattern=None, *args, **kw):
 
     pattern = kw.get('pattern', pattern)
     if pattern:
-        regex = re.compile(pattern.encode('utf-8'))
+        regex = fmn.rules.utils.compile_regex(pattern.encode('utf-8'))
         return bool(regex.search(fedmsg.encoding.dumps(message['msg'])))
 
 


### PR DESCRIPTION
A quick experiment with the ``timeit`` module shows that re2's compilation is
something like 16x slower than stdlib, but the ``.match`` operation is 10x
faster.