### PR TITLE
Work with broken Koschei rules

### DIFF
--- a/fmn/rules/koschei.py
+++ b/fmn/rules/koschei.py
@@ -22,4 +22,4 @@ def koschei_group(config, message, group=None):
     if not group or 'koschei' not in message['topic']:
         return False
     groups = set([item.strip() for item in group.split(',')])
-    return bool(groups.intersection(message['msg'].get('groups')))
+    return bool(groups.intersection(message['msg'].get('groups', [])))


### PR DESCRIPTION
Messages sent in the morning of 2015-09-25 were missing the groups
field. Deal with that not existing.

Example messages:
- 2015-eebf137e-cc22-48c2-87f0-7d736950f76b
- 2015-2a5361ec-9c36-438a-8233-709e9f006003

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>