### PR TITLE
Add taskotron

### DIFF
--- a/fmn/rules/__init__.py
+++ b/fmn/rules/__init__.py
@@ -28,5 +28,6 @@ from fmn.rules.nuancier import *
 from fmn.rules.pkgdb import *
 from fmn.rules.planet import *
 from fmn.rules.summershum import *
+from fmn.rules.taskotron import *
 from fmn.rules.trac import *
 from fmn.rules.wiki import *

--- a/fmn/rules/taskotron.py
+++ b/fmn/rules/taskotron.py
@@ -1,0 +1,28 @@
+from fmn.lib.hinting import hint, prefixed as _
+
+
+@hint(topics=[_('taskotron.result.new')])
+def taskotron_result_new(config, message):
+    """ New taskotron task result
+
+    This rule lets through messages from the `taskotron
+    <https://taskotron.fedoraproject.org>`_ about new task result.
+    """
+    return message['topic'].endswith('taskotron.result.new')
+
+@hint(categories=['taskotron'], invertible=False)
+def taskotron_task(config, message, task=None):
+    """ Particular taskotron task
+
+    With this rule, you can limit messages to only those of particular
+    `taskotron https://taskotron.fedoraproject.org/`_ task.
+
+    You can specify several tasks by separating them with a comma ',',
+    i.e.: ``depcheck,rpmlint``.
+    """
+
+    if not task:
+        return False
+
+    tasks = [item.strip() for item in task.split(',')]
+    return message['msg']['task'].get('name') in tasks


### PR DESCRIPTION
Patch for emitting taskotron fedmsgs in resultsdb is here: https://bitbucket.org/fedoraqa/resultsdb/commits/026cd9a25a20d6257baa71738213c31d4c3b459c

Pull request in fedmsg_meta_fedora_infrastructure: https://github.com/fedora-infra/fedmsg_meta_fedora_infrastructure/pull/323