### PR TITLE
Cache calls to fedmsg.meta.msg2packages.

### DIFF
--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -2,6 +2,7 @@
 
 import fedmsg
 import fedmsg.encoding
+import fedmsg.meta
 
 import fmn.rules.utils
 from fmn.lib.hinting import hint

--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -17,7 +17,7 @@ def user_filter(config, message, fasnick=None, *args, **kw):
 
     fasnick = kw.get('fasnick', fasnick)
     if fasnick:
-        return fasnick in fedmsg.meta.msg2usernames(message, **config)
+        return fasnick in fmn.rules.utils.msg2usernames(message, **config)
 
 
 @hint(callable=lambda config, fasnick: dict(not_users=[fasnick]),
@@ -36,7 +36,7 @@ def not_user_filter(config, message, fasnick=None, *args, **kw):
     fasnick = (fasnick or []) and fasnick.split(',')
     valid = True
     for nick in fasnick:
-        if nick.strip() in fedmsg.meta.msg2usernames(message, **config):
+        if nick.strip() in fmn.rules.utils.msg2usernames(message, **config):
             valid = False
             break
 
@@ -62,7 +62,7 @@ def fas_group_member_filter(config, message, group=None, *args, **kw):
     if not group:
         return False
     fasusers = _get_users_of_group(config, group)
-    msgusers = fedmsg.meta.msg2usernames(message, **config)
+    msgusers = fmn.rules.utils.msg2usernames(message, **config)
     return bool(fasusers.intersection(msgusers))
 
 
@@ -84,7 +84,7 @@ def user_package_filter(config, message, fasnick=None, *args, **kw):
 
     fasnick = kw.get('fasnick', fasnick)
     if fasnick:
-        msg_packages = fedmsg.meta.msg2packages(message, **config)
+        msg_packages = fmn.rules.utils.msg2packages(message, **config)
         if not msg_packages:
             # If the message has no packages associated with it, there's no
             # way that "one of them" is going to happen to belong to this user,
@@ -108,7 +108,7 @@ def user_package_commit_filter(config, message, fasnick=None, *args, **kw):
 
     fasnick = kw.get('fasnick', fasnick)
     if fasnick:
-        msg_packages = fedmsg.meta.msg2packages(message, **config)
+        msg_packages = fmn.rules.utils.msg2packages(message, **config)
         if not msg_packages:
             # If the message has no packages associated with it, there's no
             # way that "one of them" is going to happen to belong to this user,
@@ -133,7 +133,7 @@ def user_package_watch_filter(config, message, fasnick=None, *args, **kw):
 
     fasnick = kw.get('fasnick', fasnick)
     if fasnick:
-        msg_packages = fedmsg.meta.msg2packages(message, **config)
+        msg_packages = fmn.rules.utils.msg2packages(message, **config)
         if not msg_packages:
             # If the message has no packages associated with it, there's no
             # way that "one of them" is going to happen to belong to this user,
@@ -157,7 +157,7 @@ def package_filter(config, message, package=None, *args, **kw):
 
     package = kw.get('package', package)
     if package:
-        return package in fedmsg.meta.msg2packages(message, **config)
+        return package in fmn.rules.utils.msg2packages(message, **config)
 
 
 # Can't hint this one.  Can't pass a regex on to postgres
@@ -171,7 +171,7 @@ def package_regex_filter(config, message, pattern=None, *args, **kw):
 
     pattern = kw.get('pattern', pattern)
     if pattern:
-        packages = fedmsg.meta.msg2packages(message, **config)
+        packages = fmn.rules.utils.msg2packages(message, **config)
         regex = fmn.rules.utils.compile_regex(pattern.encode('utf-8'))
         return any([regex.search(p.encode('utf-8')) for p in packages])
 

--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -216,3 +216,24 @@ def get_groups_of_user(config, fas, username):
 
     return _cache.get_or_create(key, creator)
 
+
+def msg2usernames(msg, **config):
+    ''' Return cached fedmsg.meta.msg2usernames(...) '''
+
+    if not _cache.is_configured:
+        _cache.configure(**config['fmn.rules.cache'])
+
+    key = "|".join(['usernames', msg['msg_id']]).encode('utf-8')
+    creator = lambda: fedmsg.meta.msg2usernames(msg, **config)
+    return _cache.get_or_create(key, creator)
+
+
+def msg2packages(msg, **config):
+    ''' Return cached fedmsg.meta.msg2packages(...) '''
+
+    if not _cache.is_configured:
+        _cache.configure(**config['fmn.rules.cache'])
+
+    key = "|".join(['packages', msg['msg_id']]).encode('utf-8')
+    creator = lambda: fedmsg.meta.msg2packages(msg, **config)
+    return _cache.get_or_create(key, creator)

--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -6,6 +6,8 @@ import time
 import requests
 import requests.exceptions
 
+import fedmsg.meta
+
 from dogpile.cache import make_region
 from fedora.client.fas2 import AccountSystem
 


### PR DESCRIPTION
This should fix the large backlog we started seeing in the last few weeks.

I think it all stems from fedora-infra/fedmsg_meta_fedora_infrastructure#349,
where we gave ``fedmsg.meta.msg2packages`` the ability to query bodhi to find
the list of packages associated with a taskotron task carried out on a bodhi
update.  That operation is not slow on its own.  It is far less than a second.
But inside FMN's backend message dispatcher, it is called inside a loop over
and over again for every possible message recipient... and all of those calls
add up.  When I checked this evening, on average it takes 1500 seconds (or 25
minutes) to process a single taskotron message about a bodhi update.  All other
message types pass through in a matter of a few seconds.