### PR TITLE
Let get_user_of_group return a set()

### DIFF
--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -200,8 +200,8 @@ def get_user_of_group(config, fas, groupname):
     key = cache_key_generator(get_user_of_group, groupname)
     def creator():
         if not fas:
-            return []
-        return fas.group_members(groupname)
+            return set()
+        return set(fas.group_members(groupname))
     return _cache.get_or_create(key, creator)
 
 def get_groups_of_user(config, fas, username):


### PR DESCRIPTION
This fixes generic.fas_group_member_filter that expects fasusers to be a
set().