### PR TITLE
Fix processing messages from anitya

### DIFF
--- a/fmn/rules/anitya.py
+++ b/fmn/rules/anitya.py
@@ -55,7 +55,10 @@ def anitya_specific_distro(config, message, distro=None, *args, **kw):
         if d.get('name', '').lower() == distro.lower():
             return True
 
-    d = message['msg'].get('project', {}).get('distro', {})
+    d = None
+    p = message['msg'].get('project', {})
+    if p:
+        d = p.get('distro', {})
     if d:  # Have to be careful for None here
         if d.get('name', '').lower() == distro.lower():
             return True


### PR DESCRIPTION
Messages such as: https://apps.fedoraproject.org/datagrepper/id?is_raw=true&size=extra-large&id=2016-fc73c74c-fc5a-4f65-8ae9-87145bae82e4
Do contain a 'project' key but that key has a value `None` so instead
of having the expected `{}`, we end up with a `None` object that has no
`.get()` method of course.
With this change, we do things in two steps but at least it should work.