### PR TITLE
When retrieving the users in a group we're only interested in their username

### DIFF
--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -201,8 +201,9 @@ def get_user_of_group(config, fas, groupname):
     def creator():
         if not fas:
             return set()
-        return set(fas.group_members(groupname))
+        return set([u.username for u in fas.group_members(groupname)])
     return _cache.get_or_create(key, creator)
+
 
 def get_groups_of_user(config, fas, username):
     ''' Return the list of (pkgdb) groups to which the user belongs.


### PR DESCRIPTION
Otherwise this fails down the path.