### PR TITLE
Move requirements to requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
  - "3.3"
 
 install:
+ - pip install --upgrade setuptools
  - python setup.py install
- - pip install nose mock sqlalchemy unittest2 fmn.lib
-script: nosetests -v
+script: python setup.py test
 notifications:
     email: false
     irc: false

--- a/fedmsg.d/testconfig.py
+++ b/fedmsg.d/testconfig.py
@@ -1,0 +1,5 @@
+config = {
+    'endpoints': {
+        # Just need this entry here for tests to pass on travis-ci.
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+dogpile.cache
+fedmsg
+fedmsg_meta_fedora_infrastructure
+fmn.lib
+python-fedora
+requests
+six

--- a/setup.py
+++ b/setup.py
@@ -19,17 +19,24 @@ def get_description():
     with open('README.rst', 'r') as f:
         return ''.join(f.readlines()[2:])
 
-requires = [
-    'python-fedora',
-    'fedmsg',
-    'fedmsg_meta_fedora_infrastructure',
-    'dogpile.cache',
-    'six',
-]
 
-tests_require = [
-    'nose',
-]
+def get_requirements(filename='requirements.txt'):
+    """
+    Get the contents of a file listing the requirements.
+
+    :param requirements_file: path to a requirements file
+    :type  requirements_file: str
+
+    :returns: the list of requirements
+    :return type: list
+    """
+    with open(filename) as f:
+        return [
+            line.rstrip().split('#')[0]
+            for line in f.readlines()
+            if not line.startswith('#')
+        ]
+
 
 setup(
     name='fmn.rules',
@@ -41,8 +48,8 @@ setup(
     url="https://github.com/fedora-infra/fmn.rules",
     download_url="https://pypi.python.org/pypi/fmn.rules/",
     license='LGPLv2+',
-    install_requires=requires,
-    tests_require=tests_require,
+    install_requires=get_requirements('requirements.txt'),
+    tests_require=get_requirements('tests-requirements.txt'),
     test_suite='nose.collector',
     packages=['fmn', 'fmn.rules'],
     namespace_packages=['fmn'],

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -1,0 +1,4 @@
+# depend on html5lib for now since fmn.lib seems to be missing that dependency
+# declaration.
+html5lib
+nose


### PR DESCRIPTION
This makes it easy to `pip install -r` or use Ansible to install from a
requirements file.

Signed-off-by: Jeremy Cline jeremy@jcline.org
